### PR TITLE
Add statistics box

### DIFF
--- a/scripts/launcher.js
+++ b/scripts/launcher.js
@@ -115,7 +115,7 @@ function openTracker(loadProgress) {
 
 	//Chrome defaults
 	var h = 480;
-	var w = 1320;
+	var w = 1712;
 
 	open('tracker.html?f=' + flagStr + '&p=' + progressStr + '&v=' + versionStr + '&c=' + isCurrentVersionStr,
 		'',

--- a/scripts/launcher.js
+++ b/scripts/launcher.js
@@ -115,7 +115,7 @@ function openTracker(loadProgress) {
 
 	//Chrome defaults
 	var h = 480;
-	var w = 1712;
+	var w = 1320;
 
 	open('tracker.html?f=' + flagStr + '&p=' + progressStr + '&v=' + versionStr + '&c=' + isCurrentVersionStr,
 		'',

--- a/scripts/launcher.js
+++ b/scripts/launcher.js
@@ -115,7 +115,7 @@ function openTracker(loadProgress) {
 
 	//Chrome defaults
 	var h = 480;
-	var w = 1320;
+	var w = 1327;
 
 	open('tracker.html?f=' + flagStr + '&p=' + progressStr + '&v=' + versionStr + '&c=' + isCurrentVersionStr,
 		'',

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -495,26 +495,35 @@ function isValidForLocation(generalLocation, detailedLocation, isDungeon) {
 }
 
 function getChestCountsForLocation(generalLocation, isDungeon) {
+    var curChecked = 0;
     var curProgress = 0;
     var curAvailable = 0;
     var curTotal = 0;
     var curLocation = locationsChecked[generalLocation];
     Object.keys(curLocation).forEach(function (detailedLocation) {
-        if (isValidForLocation(generalLocation, detailedLocation, isDungeon)
-            && !locationsChecked[generalLocation][detailedLocation]) {
-            var hasProgress = locationsAreProgress[generalLocation][detailedLocation];
-            if (hasProgress || showNonProgressLocations) {
-                curTotal++;
-                if (locationsAreAvailable[generalLocation][detailedLocation]) {
-                    curAvailable++;
-                    if (hasProgress) {
-                        curProgress++;
+        if (isValidForLocation(generalLocation, detailedLocation, isDungeon)) {
+            if (!locationsChecked[generalLocation][detailedLocation]) {
+                var hasProgress = locationsAreProgress[generalLocation][detailedLocation];
+                if (hasProgress || showNonProgressLocations) {
+                    curTotal++;
+                    if (locationsAreAvailable[generalLocation][detailedLocation]) {
+                        curAvailable++;
+                        if (hasProgress) {
+                            curProgress++;
+                        }
                     }
                 }
+            } else {
+                ++curChecked;
             }
         }
     });
-    return { progress: curProgress, available: curAvailable, total: curTotal };
+    return {
+        checked: curChecked,
+        progress: curProgress,
+        available: curAvailable,
+        total: curTotal
+    };
 }
 
 function setChestCounts() {

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -344,6 +344,7 @@ function dataChanged() {
     refreshAllImagesAndCounts();
     refreshLocationColors();
     recreateTooltips();
+    updateStatistics();
 }
 
 function loadStartingItems() {

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -498,14 +498,18 @@ function getChestCountsForLocation(generalLocation, isDungeon) {
     var curChecked = 0;
     var curProgress = 0;
     var curAvailable = 0;
-    var curTotal = 0;
+    var curTotalProgress = 0;
+    var curTotalDisplayed = 0;
     var curLocation = locationsChecked[generalLocation];
     Object.keys(curLocation).forEach(function (detailedLocation) {
         if (isValidForLocation(generalLocation, detailedLocation, isDungeon)) {
+            var hasProgress = locationsAreProgress[generalLocation][detailedLocation];
             if (!locationsChecked[generalLocation][detailedLocation]) {
-                var hasProgress = locationsAreProgress[generalLocation][detailedLocation];
+                if (hasProgress) {
+                    curTotalProgress++;
+                }
                 if (hasProgress || showNonProgressLocations) {
-                    curTotal++;
+                    curTotalDisplayed++;
                     if (locationsAreAvailable[generalLocation][detailedLocation]) {
                         curAvailable++;
                         if (hasProgress) {
@@ -513,7 +517,7 @@ function getChestCountsForLocation(generalLocation, isDungeon) {
                         }
                     }
                 }
-            } else {
+            } else if (hasProgress || showNonProgressLocations) {
                 ++curChecked;
             }
         }
@@ -522,7 +526,8 @@ function getChestCountsForLocation(generalLocation, isDungeon) {
         checked: curChecked,
         progress: curProgress,
         available: curAvailable,
-        total: curTotal
+        total: curTotalDisplayed,
+        totalProgress: curTotalProgress,
     };
 }
 

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -667,6 +667,41 @@ function removeVisibleTooltips() {
     });
 }
 
+function updateStatistics() {
+    // Treasure Locations Remaining
+    var locationsRemaining = 0;
+    for (var i = 0; i < islands.length; i++) {
+        var chests = getChestCountsForLocation(islands[i], false);
+        locationsRemaining += chests.total;
+    }
+    for (var i = 0; i < dungeons.length; i++) {
+        var chests = getChestCountsForLocation(dungeons[i], true);
+        locationsRemaining += chests.total;
+    }
+    // don't include "Defeat Ganondorf" as a treasure location
+    if (!locationsChecked["Ganon's Tower"]["Defeat Ganondorf"])
+        --locationsRemaining;
+    $("#stat-locationsRemaining").text(locationsRemaining);
+
+    // Items Needed to Finish Game
+    var finishGameItems = itemsRequiredForLocation("Ganon's Tower", "Defeat Ganondorf");
+    var countdown = finishGameItems.countdown;
+    $("#stat-progressionRemaining").text(countdown);
+
+    // Chance of Endgame Find
+    var probability = Math.round(Math.min(1, countdown / locationsRemaining) * 1000) / 10;
+    $("#stat-progressProbability").text(probability + "%");
+
+    // Average Treasure Checks Remaining
+    // also known as average draws without replacement probability
+    var averageChecksRemaining = Math.min(locationsRemaining, (countdown * (locationsRemaining + 1)) / (countdown + 1));
+    $("#stat-averageRemaining").text(Math.round(averageChecksRemaining * 10) / 10);
+
+    // Estimated Locations Leftover at End
+    var leftover = locationsRemaining - averageChecksRemaining;
+    $("#stat-estimatedLeftover").text(Math.round(leftover * 10) / 10);
+}
+
 function toggleMap(index, isDungeon) {
     if (disableMap) {
         disableMap = false;

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -669,15 +669,18 @@ function updateStatistics() {
     // Locations Checked, Locations Remaining
     var checkedCount = 0;
     var locationsRemaining = 0;
+    var progressLocationsRemaining = 0;
     for (var i = 0; i < islands.length; i++) {
         var chests = getChestCountsForLocation(islands[i], false);
         checkedCount += chests.checked;
         locationsRemaining += chests.total;
+        progressLocationsRemaining += chests.totalProgress;
     }
     for (var i = 0; i < dungeons.length; i++) {
         var chests = getChestCountsForLocation(dungeons[i], true);
         checkedCount += chests.checked;
         locationsRemaining += chests.total;
+        progressLocationsRemaining += chests.totalProgress;
     }
     // don't include "Defeat Ganondorf" as a treasure location
     if (!locationsChecked["Ganon's Tower"]["Defeat Ganondorf"])
@@ -694,8 +697,8 @@ function updateStatistics() {
 
     // Estimated Locations Left Over at End
     // average checks remaining = average draws without replacement probability
-    var averageChecksRemaining = Math.min(locationsRemaining, (countdown * (locationsRemaining + 1)) / (countdown + 1));
-    var leftover = locationsRemaining - averageChecksRemaining;
+    var averageChecksRemaining = Math.min(progressLocationsRemaining, (countdown * (progressLocationsRemaining + 1)) / (countdown + 1));
+    var leftover = progressLocationsRemaining - averageChecksRemaining;
     $("#stat-estimatedLeftOver").text(Math.round(leftover * 10) / 10);
 }
 

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -216,8 +216,10 @@ function toggleLocationLogic(button) {
     hideLocationLogic = !hideLocationLogic;
     if (hideLocationLogic) {
         button.innerText = "Show Location Logic";
+        $(".requireLocationLogic").addClass("hide");
     } else {
         button.innerText = "Hide Location Logic";
+        $(".requireLocationLogic").removeClass("hide");
     }
     dataChanged();
 }

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -692,11 +692,11 @@ function updateStatistics() {
     var countdown = finishGameItems.countdown;
     $("#stat-progressionRemaining").text(countdown);
 
-    // Estimated Locations Leftover at End
+    // Estimated Locations Left Over at End
     // average checks remaining = average draws without replacement probability
     var averageChecksRemaining = Math.min(locationsRemaining, (countdown * (locationsRemaining + 1)) / (countdown + 1));
     var leftover = locationsRemaining - averageChecksRemaining;
-    $("#stat-estimatedLeftover").text(Math.round(leftover * 10) / 10);
+    $("#stat-estimatedLeftOver").text(Math.round(leftover * 10) / 10);
 }
 
 function toggleMap(index, isDungeon) {

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -688,19 +688,9 @@ function updateStatistics() {
     var countdown = finishGameItems.countdown;
     $("#stat-progressionRemaining").text(countdown);
 
-    // Chance of Endgame Find
-    var probability = 0;
-    if (locationsRemaining > 0) {
-        probability = Math.round(Math.min(1, countdown / locationsRemaining) * 1000) / 10;
-    }
-    $("#stat-progressProbability").text(probability + "%");
-
-    // Average Treasure Checks Remaining
-    // also known as average draws without replacement probability
-    var averageChecksRemaining = Math.min(locationsRemaining, (countdown * (locationsRemaining + 1)) / (countdown + 1));
-    $("#stat-averageRemaining").text(Math.round(averageChecksRemaining * 10) / 10);
-
     // Estimated Locations Leftover at End
+    // average checks remaining = average draws without replacement probability
+    var averageChecksRemaining = Math.min(locationsRemaining, (countdown * (locationsRemaining + 1)) / (countdown + 1));
     var leftover = locationsRemaining - averageChecksRemaining;
     $("#stat-estimatedLeftover").text(Math.round(leftover * 10) / 10);
 }

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -689,7 +689,10 @@ function updateStatistics() {
     $("#stat-progressionRemaining").text(countdown);
 
     // Chance of Endgame Find
-    var probability = Math.round(Math.min(1, countdown / locationsRemaining) * 1000) / 10;
+    var probability = 0;
+    if (locationsRemaining > 0) {
+        probability = Math.round(Math.min(1, countdown / locationsRemaining) * 1000) / 10;
+    }
     $("#stat-progressProbability").text(probability + "%");
 
     // Average Treasure Checks Remaining

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -668,19 +668,25 @@ function removeVisibleTooltips() {
 }
 
 function updateStatistics() {
-    // Treasure Locations Remaining
+    // Locations Checked, Locations Remaining
+    var checkedCount = 0;
     var locationsRemaining = 0;
     for (var i = 0; i < islands.length; i++) {
         var chests = getChestCountsForLocation(islands[i], false);
+        checkedCount += chests.checked;
         locationsRemaining += chests.total;
     }
     for (var i = 0; i < dungeons.length; i++) {
         var chests = getChestCountsForLocation(dungeons[i], true);
+        checkedCount += chests.checked;
         locationsRemaining += chests.total;
     }
     // don't include "Defeat Ganondorf" as a treasure location
     if (!locationsChecked["Ganon's Tower"]["Defeat Ganondorf"])
         --locationsRemaining;
+    else
+        --checkedCount;
+    $("#stat-locationsChecked").text(checkedCount);
     $("#stat-locationsRemaining").text(locationsRemaining);
 
     // Items Needed to Finish Game

--- a/scripts/tracker.js
+++ b/scripts/tracker.js
@@ -198,16 +198,12 @@ function toggleNonProgressLocations(button) {
 }
 
 function toggleSingleColorBackground(button) {
-    var itemTracker = document.getElementsByClassName("item-tracker")[0];
-    var extraLocations = document.getElementsByClassName("extra-locations")[0];
     singleColorBackground = !singleColorBackground;
     if (singleColorBackground) {
-        itemTracker.classList.add("single-color");
-        extraLocations.classList.add("single-color");
+        $(".canUseSingleColor").addClass("single-color");
         button.innerText = "Hide Single Color Background";
     } else {
-        itemTracker.classList.remove("single-color");
-        extraLocations.classList.remove("single-color");
+        $(".canUseSingleColor").removeClass("single-color");
         button.innerText = "Show Single Color Background";
     }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -224,13 +224,6 @@ legend {
     padding-bottom: 8px;
 }
 
-.tracker {
-    display: flex;
-    flex-wrap: wrap;
-    flex-grow: 1;
-    align-content: flex-start;
-}
-
 .item-tracker {
     width: 434px;
     height: 326px;
@@ -242,7 +235,6 @@ legend {
     margin-bottom: 38px;
     display: flex;
     flex-direction: column;
-    flex-shrink: 0;
     position: relative;
 }
 
@@ -322,7 +314,6 @@ legend {
     width: 364px;
     height: 346px;
     margin-bottom: 80px;
-    flex-shrink: 0;
 }
 
 #chartmap {
@@ -508,12 +499,12 @@ legend {
 }
 
 .extra-locations {
+    float: left;
     background-color: rgba(160, 160, 160, 0.85);
     width: 450px;
     height: 242px;
     margin-right: 8px;
     margin-bottom: 8px;
-    flex-shrink: 0;
 }
 
 .extra-locations.single-color {
@@ -566,17 +557,16 @@ legend {
 }
 
 .buttons {
-    flex-grow: 0;
+    clear: left;
 }
 
 .statistics {
+    float: left;
+    width: 440px;
     background-color: rgba(80, 80, 80, 0.85);
-    width: 367px;
-    height: 232px;
+    height: 86px;
     margin: 0 0 8px 0;
     padding: 5px;
-    flex-shrink: 0;
-    display: inline-block;
     white-space: normal;
     color: #bbbbbb;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -591,6 +591,10 @@ legend {
     content: ":";
 }
 
+.hide {
+    visibility: hidden;
+}
+
 #stat-locationsRemaining::before {
     content: "(";
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -511,6 +511,7 @@ legend {
     background-color: rgba(160, 160, 160, 0.85);
     width: 450px;
     height: 242px;
+    margin-right: 8px;
     margin-bottom: 8px;
     flex-shrink: 0;
 }
@@ -566,6 +567,38 @@ legend {
 
 .buttons {
     flex-grow: 0;
+}
+
+.statistics {
+    background-color: rgba(80, 80, 80, 0.85);
+    width: 367px;
+    height: 232px;
+    margin: 0 0 8px 0;
+    padding: 5px;
+    flex-shrink: 0;
+    display: inline-block;
+    white-space: normal;
+    color: #bbbbbb;
+}
+
+.statistics.single-color {
+    background-color: rgba(80, 80, 80, 1);
+}
+
+.statistics dd {
+    color: white;
+    font-weight: bold;
+    margin: 0;
+    float: right;
+}
+
+.statistics dt {
+    display: inline-block;
+    clear: both;
+}
+
+.statistics dt::after {
+    content: ":";
 }
 
 #save-progress-button {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -601,6 +601,14 @@ legend {
     content: ":";
 }
 
+#stat-locationsRemaining::before {
+    content: "(";
+}
+
+#stat-locationsRemaining::after {
+    content: ")";
+}
+
 #save-progress-button {
     margin-left: 0;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -214,6 +214,10 @@ legend {
     color: #969696;
 }
 
+.tracker {
+    flex-grow: 1;
+}
+
 .tracker-container {
     display: flex;
     min-height: 100%;
@@ -554,10 +558,6 @@ legend {
 
 .dungeon-icon {
     display: flex;
-}
-
-.buttons {
-    clear: left;
 }
 
 .statistics {

--- a/tracker.html
+++ b/tracker.html
@@ -712,10 +712,6 @@
                 <dd id="stat-locationsRemaining">1000</dd>
                 <dt>Items Needed to Finish Game</dt>
                 <dd id="stat-progressionRemaining">100</dd>
-                <dt>Chance of Endgame Find</dt>
-                <dd id="stat-progressProbability">0%</dd>
-                <dt>Average Treasure Checks Remaining</dt>
-                <dd id="stat-averageRemaining">1000</dd>
                 <dt>Estimated Locations Leftover at End</dt>
                 <dd id="stat-estimatedLeftover">1000</dd>
             </dl>

--- a/tracker.html
+++ b/tracker.html
@@ -23,7 +23,7 @@
 <body>
     <div class="tracker-container">
         <div class="tracker">
-            <div class="item-tracker">
+            <div class="item-tracker canUseSingleColor">
                 <div class="menu-items">
                     <table>
                         <tr>
@@ -620,7 +620,7 @@
                 </div>
                 <div class="tool-tip-text"></div>
             </div>
-            <div class="extra-locations">
+            <div class="extra-locations canUseSingleColor">
                 <div onmouseout="clearMapInfo();" onmouseover="dungeonMapInfo(0);" onclick="toggleMap(0, true);" class="extra-location">
                     <div class="dungeon-items">
                         <div id="smallkey0" onmouseout="clearMapItemInfo();" onmouseover="smallKeyInfo(this, 4);" onclick="toggleKey(this, 4, 0);"
@@ -707,7 +707,7 @@
                     <div id="dungeonchests6" class="extra-location-chests">10/10</div>
                 </div>
             </div>
-            <dl class="statistics">
+            <dl class="statistics canUseSingleColor">
                 <dt>Locations Checked (Remaining)</dt>
                 <dd>
                     <span id="stat-locationsChecked">1000</span>

--- a/tracker.html
+++ b/tracker.html
@@ -708,8 +708,11 @@
                 </div>
             </div>
             <dl class="statistics">
-                <dt>Treasure Locations Remaining</dt>
-                <dd id="stat-locationsRemaining">1000</dd>
+                <dt>Locations Checked (Remaining)</dt>
+                <dd>
+                    <span id="stat-locationsChecked">1000</span>
+                    <span id="stat-locationsRemaining">1000</span>
+                </dd>
                 <dt>Items Needed to Finish Game</dt>
                 <dd id="stat-progressionRemaining">100</dd>
                 <dt>Estimated Locations Leftover at End</dt>

--- a/tracker.html
+++ b/tracker.html
@@ -715,8 +715,8 @@
                 </dd>
                 <dt class="requireLocationLogic">Items Needed to Finish Game</dt>
                 <dd class="requireLocationLogic" id="stat-progressionRemaining">100</dd>
-                <dt class="requireLocationLogic">Estimated Locations Leftover at End</dt>
-                <dd class="requireLocationLogic" id="stat-estimatedLeftover">1000</dd>
+                <dt class="requireLocationLogic">Estimated Locations Left Over at End</dt>
+                <dd class="requireLocationLogic" id="stat-estimatedLeftOver">1000</dd>
             </dl>
         </div>
         <div class="buttons">

--- a/tracker.html
+++ b/tracker.html
@@ -707,6 +707,18 @@
                     <div id="dungeonchests6" class="extra-location-chests">10/10</div>
                 </div>
             </div>
+            <dl class="statistics">
+                <dt>Treasure Locations Remaining</dt>
+                <dd id="stat-locationsRemaining">1000</dd>
+                <dt>Items Needed to Finish Game</dt>
+                <dd id="stat-progressionRemaining">100</dd>
+                <dt>Chance of Endgame Find</dt>
+                <dd id="stat-progressProbability">0%</dd>
+                <dt>Average Treasure Checks Remaining</dt>
+                <dd id="stat-averageRemaining">1000</dd>
+                <dt>Estimated Locations Leftover at End</dt>
+                <dd id="stat-estimatedLeftover">1000</dd>
+            </dl>
         </div>
         <div class="buttons">
             <button id="save-progress-button" type="button" onclick="saveProgress(this)">Save Progress</button>

--- a/tracker.html
+++ b/tracker.html
@@ -713,10 +713,10 @@
                     <span id="stat-locationsChecked">1000</span>
                     <span id="stat-locationsRemaining">1000</span>
                 </dd>
-                <dt>Items Needed to Finish Game</dt>
-                <dd id="stat-progressionRemaining">100</dd>
-                <dt>Estimated Locations Leftover at End</dt>
-                <dd id="stat-estimatedLeftover">1000</dd>
+                <dt class="requireLocationLogic">Items Needed to Finish Game</dt>
+                <dd class="requireLocationLogic" id="stat-progressionRemaining">100</dd>
+                <dt class="requireLocationLogic">Estimated Locations Leftover at End</dt>
+                <dd class="requireLocationLogic" id="stat-estimatedLeftover">1000</dd>
             </dl>
         </div>
         <div class="buttons">

--- a/tracker.html
+++ b/tracker.html
@@ -620,7 +620,7 @@
                 </div>
                 <div class="tool-tip-text"></div>
             </div>
-            <div class="extra-locations" class="extra-locations">
+            <div class="extra-locations">
                 <div onmouseout="clearMapInfo();" onmouseover="dungeonMapInfo(0);" onclick="toggleMap(0, true);" class="extra-location">
                     <div class="dungeon-items">
                         <div id="smallkey0" onmouseout="clearMapItemInfo();" onmouseover="smallKeyInfo(this, 4);" onclick="toggleKey(this, 4, 0);"


### PR DESCRIPTION
## What does this pull request change?
* Adds some fun information in the tracker, inspired mostly by me wanting to be able to automatically countdown how many places were left to check and how many more items were required for Defeat Ganondorf at a quick glance. The spirit of math inspired me to add some probability related stats as well.
* ~~Slightly improves the colors of the "other locations chest counts" by adding some shadowing.~~
* Fixes one errant HTML redundancy

## To-Do
- [x] cut "Chance of Endgame Find"
- [x] cut "Average Treasure Checks Remaining" from display
- [x] finalize stat names
- [x] move stat panel to squeeze in underneath other locations panel
- [x] add "Locations Checked"
- [x] rename / move "Treasure Locations Remaining"
- [x] respect "Hide Location Logic" by hiding stats that are derived from numbers/information hidden in this state (everything except "Locations Checked/Remaining"?)

## Testing
- [x] checked Firefox and Chrome that the launcher opened a window of sufficient size to not have scroll bars and show the new content just fine
- [x] sanity checking on the Locations Remaining math (e.g. locations remaining at launch matches what randomizer claimed at launch). notably, Defeat Ganondorf has to be exempted from the count
- [x] verified items remaining to finish game count is correct and counts down as you mark off triforce, progress sword/bow, etc.
- [x] sanity checked the endgame find probability formula (100% if only endgame items remain)
- [x] sanity checked average treasure checks remaining (= locations remaining if only endgame items remain)
- [x] tested that Hide Locaiton Logic hides all stats except Locations Checked/Remaining
- [x] tested wrapping with new float strategy and verified the stat box fits underneath other locations

## Other thoughts
Naming of the stats is obviously very open to suggestion, as well as what is included (or not) in the long run