### PR TITLE
Letter tooltips - hacky solution

### DIFF
--- a/scripts/items_required_logic.js
+++ b/scripts/items_required_logic.js
@@ -43,6 +43,9 @@ function itemsForRequirement(reqName) {
     var reqMet = true;
     var remainingProgress = 0;
   }
+  else {
+    console.log('Unrecognized reqName: "' + reqName + '"');
+  }
   return { items: requiredItems, eval: reqMet, countdown: remainingProgress };
 }
 

--- a/scripts/logic_tweaks.js
+++ b/scripts/logic_tweaks.js
@@ -79,7 +79,7 @@ function addMailTooltips() {
 
 function addNeedToItem(itemName, requiredItem) {
   var oldNeeds = itemLocations[itemName].Need;
-  var newNeeds = "(" + oldNeeds + ") & " + requiredItem;
+  var newNeeds = "( " + oldNeeds + " ) & " + requiredItem;
   itemLocations[itemName].Need = newNeeds;
 }
 

--- a/scripts/logic_tweaks.js
+++ b/scripts/logic_tweaks.js
@@ -1,6 +1,7 @@
 function updateLocations() {
   addDefeatGanondorf();
   updateTingleStatueReward();
+  addMailTooltips();
 }
 
 function updateMacros() {
@@ -67,6 +68,19 @@ function updateTingleStatueReward() {
   if (tingleStatueReward) {
     tingleStatueReward.Need = 'Tingle Statue x5';
   }
+}
+
+function addMailTooltips() {
+  addNeedToItem("Mailbox - Letter from Baito", letterTooltipItems.beatET);
+  addNeedToItem("Mailbox - Letter from Orca", letterTooltipItems.beatFW);
+  addNeedToItem("Mailbox - Letter from Aryll", letterTooltipItems.beatFF);
+  addNeedToItem("Mailbox - Letter from Tingle", letterTooltipItems.beatFF);
+}
+
+function addNeedToItem(itemName, requiredItem) {
+  var oldNeeds = itemLocations[itemName].Need;
+  var newNeeds = "(" + oldNeeds + ") & " + requiredItem;
+  itemLocations[itemName].Need = newNeeds;
 }
 
 function clearRaceModeBannedLocations() {

--- a/scripts/main_logic.js
+++ b/scripts/main_logic.js
@@ -77,6 +77,10 @@ function loadStartingItems() {
   startingItems['Ballad of Gales'] = 1;
   startingItems['Song of Passing'] = 1;
   startingItems['Triforce Shard'] = options.num_starting_triforce_shards;
+  
+  Object.keys(letterTooltipItems).forEach(function (tooltip) {
+    startingItems[tooltip] = 1;
+  })
 
   var gearRemaining = options.starting_gear;
   for (var i = 0; i < regularItems.length; i++) {

--- a/scripts/main_logic.js
+++ b/scripts/main_logic.js
@@ -77,10 +77,6 @@ function loadStartingItems() {
   startingItems['Ballad of Gales'] = 1;
   startingItems['Song of Passing'] = 1;
   startingItems['Triforce Shard'] = options.num_starting_triforce_shards;
-  
-  Object.keys(letterTooltipItems).forEach(function (tooltip) {
-    startingItems[tooltip] = 1;
-  })
 
   var gearRemaining = options.starting_gear;
   for (var i = 0; i < regularItems.length; i++) {
@@ -107,6 +103,12 @@ function loadStartingItems() {
   if (!loadingProgress) {
     Object.keys(startingItems).forEach(function (item) {
       items[item] = startingItems[item];
+    });
+
+    // Can't include these in startingItems; starting items are hidden
+    // from tool tips.
+    Object.values(letterTooltipItems).forEach(function (tooltip) {
+      items[tooltip] = 1;
     });
   }
 }

--- a/scripts/variables.js
+++ b/scripts/variables.js
@@ -186,10 +186,10 @@ const progressiveItems = [
 // These "items" are just tooltips for some letters.
 // They are given to the player at the start of the game.
 const letterTooltipItems = {
-  beatFW: 'Beat Kalle Demos (Forbidden Woods)',
-  beatET: 'Beat Jalhalla (Earth Temple)',
-  beatFF: 'Beat Helmaroc King (Forsaken Fortress)'
-]
+  beatFW: 'Beat Kalle Demos in Forbidden Woods',
+  beatET: 'Beat Jalhalla in Earth Temple',
+  beatFF: 'Beat Helmaroc King in Forsaken Fortress'
+};
 
 var items = {
   'Tingle Tuner': 0,
@@ -245,16 +245,14 @@ var items = {
   "Hero's Charm": 0,
   'Progressive Quiver': 0,
   'Progressive Bomb Bag': 0,
-  'Hurricane Spin': 0
+  'Hurricane Spin': 0,
+
+  'Beat Kalle Demos in Forbidden Woods': 0,
+  'Beat Jalhalla in Earth Temple': 0,
+  'Beat Helmaroc King in Forsaken Fortress': 0
 };
 
-// the items you get at the start of a new playthrough
-var startingItems = {
-  // These "items" are just tooltips for some letters.
-  'Beat Kalle Demos (Forbidden Woods)',
-  'Beat Jalhalla (Earth Temple)',
-  'Beat Helmaroc King (Forsaken Fortress)'
-};
+var startingItems = {}; // the items you get at the start of a new playthrough
 var impossibleItems = []; // the items that are missing from the item pool and are impossible to obtain
 var keys = {
   'DRC Big Key': 0,

--- a/scripts/variables.js
+++ b/scripts/variables.js
@@ -183,6 +183,13 @@ const progressiveItems = [
   'Progressive Sword',
   'Progressive Wallet'
 ];
+// These "items" are just tooltips for some letters.
+// They are given to the player at the start of the game.
+const letterTooltipItems = {
+  beatFW: 'Beat Kalle Demos (Forbidden Woods)',
+  beatET: 'Beat Jalhalla (Earth Temple)',
+  beatFF: 'Beat Helmaroc King (Forsaken Fortress)'
+]
 
 var items = {
   'Tingle Tuner': 0,
@@ -240,7 +247,14 @@ var items = {
   'Progressive Bomb Bag': 0,
   'Hurricane Spin': 0
 };
-var startingItems = {}; // the items you get at the start of a new playthrough
+
+// the items you get at the start of a new playthrough
+var startingItems = {
+  // These "items" are just tooltips for some letters.
+  'Beat Kalle Demos (Forbidden Woods)',
+  'Beat Jalhalla (Earth Temple)',
+  'Beat Helmaroc King (Forsaken Fortress)'
+};
 var impossibleItems = []; // the items that are missing from the item pool and are impossible to obtain
 var keys = {
   'DRC Big Key': 0,


### PR DESCRIPTION
This PR implements option 1 in #36. My other PR implements option 2. If this PR is merged, my other PR should be closed.

This PR adds three dummy items: "Beaten <boss name> in <dungeon>" for Forsaken Fortress, Forbidden Woods, and Earth Temple. Then it adds these items to the player's starting items, so that they're never used for actual logic. Finally, it changes the four letters that depend on beating bosses (Baito, Orca, Aryll, and Tingle) to depend on these items.

The final result is an extra line of text under the letters, describing what triggers them. No change in the logical behavior, just a tip for newer players.

This is a small and simple solution that's easy to maintain.