### PR TITLE
Letter tooltips - logic solution

### DIFF
--- a/scripts/items_required_logic.js
+++ b/scripts/items_required_logic.js
@@ -20,6 +20,12 @@ function itemsForRequirement(reqName) {
     }
   } else if (reqName.startsWith('Can Access Other Location "')) {
     return itemsRequiredForOtherLocation(reqName);
+  } else if (reqName.startsWith('Has Accessed Other Location "')) {
+    var otherLocation = reqName.substring('Has Accessed Other Location "'.length, reqName.length - 1);
+    var splitName = getSplitLocationName(otherLocation);
+    var reqMet = locationsChecked[splitName.general][splitName.detailed];
+    var requiredItems = otherLocation;
+    var remainingProgress = reqMet ? 0 : 1;
   } else if (reqName.startsWith('Option "')) {
     var reqMet = checkOptionEnabledRequirement(reqName);
     var requiredItems = reqMet ? 'None' : 'Impossible';
@@ -42,6 +48,9 @@ function itemsForRequirement(reqName) {
     var requiredItems = 'None';
     var reqMet = true;
     var remainingProgress = 0;
+  }
+  else {
+    console.log("Unrecognized reqName: " + reqName);
   }
   return { items: requiredItems, eval: reqMet, countdown: remainingProgress };
 }

--- a/scripts/locations_logic.js
+++ b/scripts/locations_logic.js
@@ -107,6 +107,9 @@ function checkRequirementMet(reqName) {
   if (reqName.startsWith('Can Access Other Location "')) {
     return checkOtherLocationReq(reqName);
   }
+  if (reqName.startsWith('Has Accessed Other Location "')) {
+    return checkHasAccessedOtherLocationReq(reqName);
+  }
   if (reqName.startsWith('Option "')) {
     return checkOptionEnabledRequirement(reqName);
   }
@@ -155,6 +158,12 @@ function checkOtherLocationReq(reqName) {
   var otherLocation = reqName.substring('Can Access Other Location "'.length, reqName.length - 1);
   var requirements = getLocationRequirements(otherLocation);
   return checkLogicalExpressionReq(requirements);
+}
+
+function checkHasAccessedOtherLocationReq(reqName) {
+  var otherLocation = reqName.substring('Has Accessed Other Location "'.length, reqName.length - 1);
+  var split = getSplitLocationName(otherLocation);
+  return locationsChecked[split.general][split.detailed];
 }
 
 function checkOptionEnabledRequirement(reqName) {

--- a/scripts/logic_tweaks.js
+++ b/scripts/logic_tweaks.js
@@ -1,7 +1,18 @@
+// These letters are sent after the boss is defeated. However, the normal
+// randomizer logic file doesn't distinguish between "can access the boss" and
+// "has beaten the boss". These items are updated to require checking the referenced
+// location, rather than just having access to it.
+const mustAccessLocationTweaks = [
+  "Mailbox - Letter from Baito",
+  "Mailbox - Letter from Orca",
+  "Mailbox - Letter from Aryll",
+  "Mailbox - Letter from Tingle"
+];
+
 function updateLocations() {
   addDefeatGanondorf();
   updateTingleStatueReward();
-  addMailRequirements();
+  applyMustAccessTweaks();
 }
 
 function updateMacros() {
@@ -70,17 +81,12 @@ function updateTingleStatueReward() {
   }
 }
 
-function addMailRequirements() {
-  const mailToChange = [
-    "Mailbox - Letter from Baito",
-    "Mailbox - Letter from Orca",
-    "Mailbox - Letter from Aryll",
-    "Mailbox - Letter from Tingle"
-  ];
-
-  for (var i = 0; i < mailToChange.length; i++) {
-    var locationName = mailToChange[i];
-    itemLocations[locationName].Need.replace("Can Access Other Location", "Has Accessed Other Location");
+function applyMustAccessTweaks() {
+  for (var i = 0; i < mustAccessLocationTweaks.length; i++) {
+    var locationName = mustAccessLocationTweaks[i];
+    var oldNeeds = itemLocations[locationName].Need;
+    var newNeeds = oldNeeds.replace("Can Access Other Location", "Has Accessed Other Location");
+    itemLocations[locationName].Need = newNeeds;
   }
 }
 

--- a/scripts/logic_tweaks.js
+++ b/scripts/logic_tweaks.js
@@ -1,6 +1,7 @@
 function updateLocations() {
   addDefeatGanondorf();
   updateTingleStatueReward();
+  addMailRequirements();
 }
 
 function updateMacros() {
@@ -66,6 +67,20 @@ function updateTingleStatueReward() {
   var tingleStatueReward = itemLocations['Tingle Island - Ankle - Reward for All Tingle Statues'];
   if (tingleStatueReward) {
     tingleStatueReward.Need = 'Tingle Statue x5';
+  }
+}
+
+function addMailRequirements() {
+  const mailToChange = [
+    "Mailbox - Letter from Baito",
+    "Mailbox - Letter from Orca",
+    "Mailbox - Letter from Aryll",
+    "Mailbox - Letter from Tingle"
+  ];
+
+  for (var i = 0; i < mailToChange.length; i++) {
+    var locationName = mailToChange[i];
+    itemLocations[loctioName].Need.replace("Can Access Other Location", "Has Accessed Other Location");
   }
 }
 

--- a/scripts/logic_tweaks.js
+++ b/scripts/logic_tweaks.js
@@ -80,7 +80,7 @@ function addMailRequirements() {
 
   for (var i = 0; i < mailToChange.length; i++) {
     var locationName = mailToChange[i];
-    itemLocations[loctioName].Need.replace("Can Access Other Location", "Has Accessed Other Location");
+    itemLocations[locationName].Need.replace("Can Access Other Location", "Has Accessed Other Location");
   }
 }
 


### PR DESCRIPTION
Fix #36 

The wind waker randomizer doesn't distinguish between "can access the boss's heart container" and "has accessed the boss's heart container". This PR adds a new expression type, `Has Accessed Other Location "<location name>"`. It also adds a tweak for the four letters that depend on bosses (Baito, Orca, Aryll, and Tingle) to change their "Can Access ... Heart Container" to "Has Accessed ... Heart Container".

The letters now display the name of the location that the user must access - the boss's heart container. They will not be considered "accessible" until the user checks off the boss's heart container, and has fulfilled any other usual requirements (Tingle's letter also requires the wallet).

This is solution is a bit more complicated than option 1. It modifies the expression logic and is more lines of code overall. However, it's robust and might be useful for other items; and it's also much more sequence-break friendly. For example, if you manage to get into forsaken fortress without using bombs (by clipping through bounds), this new code will still tell the user that tingle's letter is available.