### PR TITLE
Fix Ghost Ship Chart label when charts are randomized

### DIFF
--- a/src/services/logic-helper.js
+++ b/src/services/logic-helper.js
@@ -474,7 +474,7 @@ export default class LogicHelper {
   }
 
   static _prettyNameOverride(itemName, itemCount = 1) {
-    if (Settings.getOptionValue(Permalink.OPTIONS.RANDOMIZE_CHARTS) && _.includes(itemName, ' Chart')) {
+    if (Settings.getOptionValue(Permalink.OPTIONS.RANDOMIZE_CHARTS) && itemName.match(/(Treasure|Triforce) Chart (\d)+/)) {
       const islandIndex = _.indexOf(CHARTS, itemName);
       return `Chart for ${_.get(ISLANDS, islandIndex)}`;
     }

--- a/src/services/logic-helper.test.js
+++ b/src/services/logic-helper.test.js
@@ -1884,6 +1884,12 @@ describe('LogicHelper', () => {
 
         expect(prettyName).toEqual('Chart for Forsaken Fortress');
       });
+
+      test('returns the regular name for the Ghost Ship Chart', () => {
+        const prettyName = LogicHelper.prettyNameForItem('Ghost Ship Chart');
+
+        expect(prettyName).toEqual('Ghost Ship Chart');
+      });
     });
 
     describe('when charts are not randomized', () => {
@@ -1905,6 +1911,12 @@ describe('LogicHelper', () => {
         const prettyName = LogicHelper.prettyNameForItem('Treasure Chart 25');
 
         expect(prettyName).toEqual('Treasure Chart 25');
+      });
+
+      test('returns the regular name for the Ghost Ship Chart', () => {
+        const prettyName = LogicHelper.prettyNameForItem('Ghost Ship Chart');
+
+        expect(prettyName).toEqual('Ghost Ship Chart');
       });
     });
   });


### PR DESCRIPTION
The Ghost Ship Chart was previously displayed as "Chart for undefined" when charts were randomized.