### PR TITLE
Ability to decrement item count

### DIFF
--- a/src/services/tracker-state.js
+++ b/src/services/tracker-state.js
@@ -57,6 +57,19 @@ export default class TrackerState {
     return newState;
   }
 
+  decrementItem(itemName) {
+    const newState = this._clone();
+
+    let newItemCount = this.getItemValue(itemName) - 1;
+    const minItemCount = LogicHelper.startingItemCount(itemName);
+    if (newItemCount < minItemCount) {
+      newItemCount = LogicHelper.maxItemCount(itemName);
+    }
+    _.set(newState.items, itemName, newItemCount);
+
+    return newState;
+  }
+
   getEntranceForExit(dungeonOrCaveName) {
     return _.get(this.entrances, dungeonOrCaveName);
   }

--- a/src/services/tracker-state.test.js
+++ b/src/services/tracker-state.test.js
@@ -196,6 +196,67 @@ describe('TrackerState', () => {
     });
   });
 
+  describe('decrementItem', () => {
+    let state;
+    let initialEntrances;
+    let initialLocationsChecked;
+
+    beforeEach(() => {
+      initialEntrances = {
+        'Needle Rock Isle Secret Cave': 'Dragon Roost Cavern',
+      };
+      initialLocationsChecked = {
+        'Dragon Roost Cavern': {
+          "Bird's Nest": true,
+        },
+      };
+
+      state = new TrackerState();
+
+      state.entrances = _.clone(initialEntrances);
+      state.locationsChecked = _.cloneDeep(initialLocationsChecked);
+    });
+
+    describe('when the item is already at min quantity', () => {
+      beforeEach(() => {
+        LogicHelper.startingItems = {
+          'Progressive Sword': 2,
+        };
+
+        state.items = {
+          'Progressive Sword': 2,
+        };
+      });
+
+      test('returns a new state with the item reset to the maximum quantity', () => {
+        const newState = state.decrementItem('Progressive Sword');
+
+        expect(newState.items['Progressive Sword']).toEqual(4);
+      });
+    });
+
+    describe('when the item is not already at min quantity', () => {
+      beforeEach(() => {
+        state.items = {
+          'Deku Leaf': 1,
+        };
+      });
+
+      test('returns a new state with the item count decremented by 1', () => {
+        const newState = state.decrementItem('Deku Leaf');
+
+        expect(newState.items['Deku Leaf']).toEqual(0);
+      });
+    });
+
+    test('keeps the other values unmodified', () => {
+      const newState = state.decrementItem('Deku Leaf');
+
+      expect(newState.entrances).toEqual(initialEntrances);
+      expect(newState.locationsChecked).toEqual(initialLocationsChecked);
+    });
+  });
+
   describe('getEntranceForExit', () => {
     let state;
 

--- a/src/ui/extra-location.jsx
+++ b/src/ui/extra-location.jsx
@@ -12,6 +12,7 @@ class ExtraLocation extends React.PureComponent {
     const {
       clearSelectedItem,
       incrementItem,
+      decrementItem,
       setSelectedItem,
       smallKeyCount,
       smallKeyName,
@@ -25,6 +26,7 @@ class ExtraLocation extends React.PureComponent {
           clearSelectedItem={clearSelectedItem}
           images={smallKeyImages}
           incrementItem={incrementItem}
+          decrementItem={decrementItem}
           itemCount={smallKeyCount}
           itemName={smallKeyName}
           setSelectedItem={setSelectedItem}
@@ -39,6 +41,7 @@ class ExtraLocation extends React.PureComponent {
       bigKeyName,
       clearSelectedItem,
       incrementItem,
+      decrementItem,
       setSelectedItem,
     } = this.props;
 
@@ -50,6 +53,7 @@ class ExtraLocation extends React.PureComponent {
           clearSelectedItem={clearSelectedItem}
           images={bigKeyImages}
           incrementItem={incrementItem}
+          decrementItem={decrementItem}
           itemCount={bigKeyCount}
           itemName={bigKeyName}
           setSelectedItem={setSelectedItem}
@@ -183,6 +187,7 @@ ExtraLocation.defaultProps = {
   entryCount: null,
   entryName: null,
   incrementItem: null,
+  decrementItem: null,
   setSelectedExit: null,
   setSelectedItem: null,
   smallKeyCount: null,
@@ -201,6 +206,7 @@ ExtraLocation.propTypes = {
   entryCount: PropTypes.number,
   entryName: PropTypes.string,
   incrementItem: PropTypes.func,
+  decrementItem: PropTypes.func,
   isDungeon: PropTypes.bool.isRequired,
   isMainDungeon: PropTypes.bool.isRequired,
   locationIcon: PropTypes.string.isRequired,

--- a/src/ui/extra-location.jsx
+++ b/src/ui/extra-location.jsx
@@ -11,8 +11,8 @@ class ExtraLocation extends React.PureComponent {
   smallKeyItem() {
     const {
       clearSelectedItem,
-      incrementItem,
       decrementItem,
+      incrementItem,
       setSelectedItem,
       smallKeyCount,
       smallKeyName,
@@ -24,9 +24,9 @@ class ExtraLocation extends React.PureComponent {
       <div className="dungeon-item small-key">
         <Item
           clearSelectedItem={clearSelectedItem}
+          decrementItem={decrementItem}
           images={smallKeyImages}
           incrementItem={incrementItem}
-          decrementItem={decrementItem}
           itemCount={smallKeyCount}
           itemName={smallKeyName}
           setSelectedItem={setSelectedItem}
@@ -40,8 +40,8 @@ class ExtraLocation extends React.PureComponent {
       bigKeyCount,
       bigKeyName,
       clearSelectedItem,
-      incrementItem,
       decrementItem,
+      incrementItem,
       setSelectedItem,
     } = this.props;
 
@@ -51,9 +51,9 @@ class ExtraLocation extends React.PureComponent {
       <div className="dungeon-item big-key">
         <Item
           clearSelectedItem={clearSelectedItem}
+          decrementItem={decrementItem}
           images={bigKeyImages}
           incrementItem={incrementItem}
-          decrementItem={decrementItem}
           itemCount={bigKeyCount}
           itemName={bigKeyName}
           setSelectedItem={setSelectedItem}
@@ -184,10 +184,10 @@ ExtraLocation.defaultProps = {
   bigKeyCount: null,
   bigKeyName: null,
   clearSelectedItem: null,
+  decrementItem: null,
   entryCount: null,
   entryName: null,
   incrementItem: null,
-  decrementItem: null,
   setSelectedExit: null,
   setSelectedItem: null,
   smallKeyCount: null,
@@ -202,11 +202,11 @@ ExtraLocation.propTypes = {
   clearSelectedItem: PropTypes.func,
   clearSelectedLocation: PropTypes.func.isRequired,
   color: PropTypes.string.isRequired,
+  decrementItem: PropTypes.func,
   disableLogic: PropTypes.bool.isRequired,
   entryCount: PropTypes.number,
   entryName: PropTypes.string,
   incrementItem: PropTypes.func,
-  decrementItem: PropTypes.func,
   isDungeon: PropTypes.bool.isRequired,
   isMainDungeon: PropTypes.bool.isRequired,
   locationIcon: PropTypes.string.isRequired,

--- a/src/ui/extra-locations-table.jsx
+++ b/src/ui/extra-locations-table.jsx
@@ -16,6 +16,7 @@ class ExtraLocationsTable extends React.PureComponent {
       clearSelectedLocation,
       disableLogic,
       incrementItem,
+      decrementItem,
       logic,
       onlyProgressLocations,
       setSelectedExit,
@@ -71,6 +72,7 @@ class ExtraLocationsTable extends React.PureComponent {
           entryName={entryName}
           key={locationName}
           incrementItem={incrementItem}
+          decrementItem={decrementItem}
           isDungeon={isDungeon}
           isMainDungeon={isMainDungeon}
           locationIcon={locationIcon}
@@ -132,6 +134,7 @@ ExtraLocationsTable.propTypes = {
   clearSelectedLocation: PropTypes.func.isRequired,
   disableLogic: PropTypes.bool.isRequired,
   incrementItem: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   logic: PropTypes.instanceOf(LogicCalculation).isRequired,
   onlyProgressLocations: PropTypes.bool.isRequired,
   setSelectedExit: PropTypes.func.isRequired,

--- a/src/ui/extra-locations-table.jsx
+++ b/src/ui/extra-locations-table.jsx
@@ -14,9 +14,9 @@ class ExtraLocationsTable extends React.PureComponent {
     const {
       clearSelectedItem,
       clearSelectedLocation,
+      decrementItem,
       disableLogic,
       incrementItem,
-      decrementItem,
       logic,
       onlyProgressLocations,
       setSelectedExit,
@@ -67,12 +67,12 @@ class ExtraLocationsTable extends React.PureComponent {
           clearSelectedItem={clearSelectedItem}
           clearSelectedLocation={clearSelectedLocation}
           color={color}
+          decrementItem={decrementItem}
           disableLogic={disableLogic}
           entryCount={entryCount}
           entryName={entryName}
           key={locationName}
           incrementItem={incrementItem}
-          decrementItem={decrementItem}
           isDungeon={isDungeon}
           isMainDungeon={isMainDungeon}
           locationIcon={locationIcon}
@@ -132,9 +132,9 @@ class ExtraLocationsTable extends React.PureComponent {
 ExtraLocationsTable.propTypes = {
   clearSelectedItem: PropTypes.func.isRequired,
   clearSelectedLocation: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   disableLogic: PropTypes.bool.isRequired,
   incrementItem: PropTypes.func.isRequired,
-  decrementItem: PropTypes.func.isRequired,
   logic: PropTypes.instanceOf(LogicCalculation).isRequired,
   onlyProgressLocations: PropTypes.bool.isRequired,
   setSelectedExit: PropTypes.func.isRequired,

--- a/src/ui/item.jsx
+++ b/src/ui/item.jsx
@@ -8,9 +8,9 @@ class Item extends React.PureComponent {
   render() {
     const {
       clearSelectedItem,
+      decrementItem,
       images,
       incrementItem,
-      decrementItem,
       itemCount,
       itemName,
       setSelectedItem,
@@ -35,9 +35,9 @@ class Item extends React.PureComponent {
 
     const decrementItemFunc = (event) => {
       event.preventDefault();
-      
+
       decrementItem(itemName);
-    }
+    };
 
     const setSelectedItemFunc = () => setSelectedItem(itemName);
 
@@ -46,11 +46,11 @@ class Item extends React.PureComponent {
         className={`item-container ${itemClassName}`}
         onBlur={clearSelectedItem}
         onClick={incrementItemFunc}
+        onContextMenu={decrementItemFunc}
         onFocus={setSelectedItemFunc}
         onKeyDown={incrementItemFunc}
         onMouseOver={setSelectedItemFunc}
         onMouseOut={clearSelectedItem}
-        onContextMenu={decrementItemFunc}
         role="button"
         tabIndex="0"
       >
@@ -65,9 +65,9 @@ class Item extends React.PureComponent {
 
 Item.propTypes = {
   clearSelectedItem: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   images: PropTypes.arrayOf(PropTypes.string).isRequired,
   incrementItem: PropTypes.func.isRequired,
-  decrementItem: PropTypes.func.isRequired,
   itemCount: PropTypes.number.isRequired,
   itemName: PropTypes.string.isRequired,
   setSelectedItem: PropTypes.func.isRequired,

--- a/src/ui/item.jsx
+++ b/src/ui/item.jsx
@@ -10,6 +10,7 @@ class Item extends React.PureComponent {
       clearSelectedItem,
       images,
       incrementItem,
+      decrementItem,
       itemCount,
       itemName,
       setSelectedItem,
@@ -32,6 +33,12 @@ class Item extends React.PureComponent {
       incrementItem(itemName);
     };
 
+    const decrementItemFunc = (event) => {
+      event.preventDefault();
+      
+      decrementItem(itemName);
+    }
+
     const setSelectedItemFunc = () => setSelectedItem(itemName);
 
     return (
@@ -43,6 +50,7 @@ class Item extends React.PureComponent {
         onKeyDown={incrementItemFunc}
         onMouseOver={setSelectedItemFunc}
         onMouseOut={clearSelectedItem}
+        onContextMenu={decrementItemFunc}
         role="button"
         tabIndex="0"
       >
@@ -59,6 +67,7 @@ Item.propTypes = {
   clearSelectedItem: PropTypes.func.isRequired,
   images: PropTypes.arrayOf(PropTypes.string).isRequired,
   incrementItem: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   itemCount: PropTypes.number.isRequired,
   itemName: PropTypes.string.isRequired,
   setSelectedItem: PropTypes.func.isRequired,

--- a/src/ui/items-table.jsx
+++ b/src/ui/items-table.jsx
@@ -47,6 +47,7 @@ class ItemsTable extends React.PureComponent {
   item(itemName) {
     const {
       incrementItem,
+      decrementItem,
       trackerState,
     } = this.props;
 
@@ -58,6 +59,7 @@ class ItemsTable extends React.PureComponent {
         clearSelectedItem={this.clearSelectedItem}
         images={itemImages}
         incrementItem={incrementItem}
+        decrementItem={decrementItem}
         itemCount={itemCount}
         itemName={itemName}
         setSelectedItem={this.setSelectedItem}
@@ -182,6 +184,7 @@ class ItemsTable extends React.PureComponent {
 
 ItemsTable.propTypes = {
   incrementItem: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   singleColorBackground: PropTypes.bool.isRequired,
   trackerState: PropTypes.instanceOf(TrackerState).isRequired,
 };

--- a/src/ui/items-table.jsx
+++ b/src/ui/items-table.jsx
@@ -46,8 +46,8 @@ class ItemsTable extends React.PureComponent {
 
   item(itemName) {
     const {
-      incrementItem,
       decrementItem,
+      incrementItem,
       trackerState,
     } = this.props;
 
@@ -57,9 +57,9 @@ class ItemsTable extends React.PureComponent {
     return (
       <Item
         clearSelectedItem={this.clearSelectedItem}
+        decrementItem={decrementItem}
         images={itemImages}
         incrementItem={incrementItem}
-        decrementItem={decrementItem}
         itemCount={itemCount}
         itemName={itemName}
         setSelectedItem={this.setSelectedItem}
@@ -183,8 +183,8 @@ class ItemsTable extends React.PureComponent {
 }
 
 ItemsTable.propTypes = {
-  incrementItem: PropTypes.func.isRequired,
   decrementItem: PropTypes.func.isRequired,
+  incrementItem: PropTypes.func.isRequired,
   singleColorBackground: PropTypes.bool.isRequired,
   trackerState: PropTypes.instanceOf(TrackerState).isRequired,
 };

--- a/src/ui/locations-table.jsx
+++ b/src/ui/locations-table.jsx
@@ -60,10 +60,10 @@ class LocationsTable extends React.PureComponent {
     const {
       clearOpenedMenus,
       clearRaceModeBannedLocations,
+      decrementItem,
       disableLogic,
       entrancesListOpen,
       incrementItem,
-      decrementItem,
       logic,
       onlyProgressLocations,
       openedExit,
@@ -123,9 +123,9 @@ class LocationsTable extends React.PureComponent {
         <SeaChart
           clearSelectedItem={this.clearSelectedItem}
           clearSelectedLocation={this.clearSelectedLocation}
+          decrementItem={decrementItem}
           disableLogic={disableLogic}
           incrementItem={incrementItem}
-          decrementItem={decrementItem}
           logic={logic}
           onlyProgressLocations={onlyProgressLocations}
           setSelectedExit={this.setSelectedExit}
@@ -158,9 +158,9 @@ class LocationsTable extends React.PureComponent {
 
   render() {
     const {
+      decrementItem,
       disableLogic,
       incrementItem,
-      decrementItem,
       logic,
       onlyProgressLocations,
       singleColorBackground,
@@ -176,9 +176,9 @@ class LocationsTable extends React.PureComponent {
         <ExtraLocationsTable
           clearSelectedItem={this.clearSelectedItem}
           clearSelectedLocation={this.clearSelectedLocation}
+          decrementItem={decrementItem}
           disableLogic={disableLogic}
           incrementItem={incrementItem}
-          decrementItem={decrementItem}
           logic={logic}
           onlyProgressLocations={onlyProgressLocations}
           setSelectedExit={this.setSelectedExit}
@@ -204,10 +204,10 @@ LocationsTable.defaultProps = {
 LocationsTable.propTypes = {
   clearOpenedMenus: PropTypes.func.isRequired,
   clearRaceModeBannedLocations: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   disableLogic: PropTypes.bool.isRequired,
   entrancesListOpen: PropTypes.bool.isRequired,
   incrementItem: PropTypes.func.isRequired,
-  decrementItem: PropTypes.func.isRequired,
   logic: PropTypes.instanceOf(LogicCalculation).isRequired,
   onlyProgressLocations: PropTypes.bool.isRequired,
   openedExit: PropTypes.string,

--- a/src/ui/locations-table.jsx
+++ b/src/ui/locations-table.jsx
@@ -63,6 +63,7 @@ class LocationsTable extends React.PureComponent {
       disableLogic,
       entrancesListOpen,
       incrementItem,
+      decrementItem,
       logic,
       onlyProgressLocations,
       openedExit,
@@ -124,6 +125,7 @@ class LocationsTable extends React.PureComponent {
           clearSelectedLocation={this.clearSelectedLocation}
           disableLogic={disableLogic}
           incrementItem={incrementItem}
+          decrementItem={decrementItem}
           logic={logic}
           onlyProgressLocations={onlyProgressLocations}
           setSelectedExit={this.setSelectedExit}
@@ -158,6 +160,7 @@ class LocationsTable extends React.PureComponent {
     const {
       disableLogic,
       incrementItem,
+      decrementItem,
       logic,
       onlyProgressLocations,
       singleColorBackground,
@@ -175,6 +178,7 @@ class LocationsTable extends React.PureComponent {
           clearSelectedLocation={this.clearSelectedLocation}
           disableLogic={disableLogic}
           incrementItem={incrementItem}
+          decrementItem={decrementItem}
           logic={logic}
           onlyProgressLocations={onlyProgressLocations}
           setSelectedExit={this.setSelectedExit}
@@ -203,6 +207,7 @@ LocationsTable.propTypes = {
   disableLogic: PropTypes.bool.isRequired,
   entrancesListOpen: PropTypes.bool.isRequired,
   incrementItem: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   logic: PropTypes.instanceOf(LogicCalculation).isRequired,
   onlyProgressLocations: PropTypes.bool.isRequired,
   openedExit: PropTypes.string,

--- a/src/ui/sea-chart.jsx
+++ b/src/ui/sea-chart.jsx
@@ -15,9 +15,9 @@ class SeaChart extends React.PureComponent {
     const {
       clearSelectedItem,
       clearSelectedLocation,
+      decrementItem,
       disableLogic,
       incrementItem,
-      decrementItem,
       logic,
       onlyProgressLocations,
       setSelectedExit,
@@ -70,11 +70,11 @@ class SeaChart extends React.PureComponent {
         color={color}
         clearSelectedItem={clearSelectedItem}
         clearSelectedLocation={clearSelectedLocation}
+        decrementItem={decrementItem}
         disableLogic={disableLogic}
         entrances={entrances}
         key={island}
         incrementItem={incrementItem}
-        decrementItem={decrementItem}
         island={island}
         numAvailable={numAvailable}
         numRemaining={numRemaining}
@@ -107,9 +107,9 @@ class SeaChart extends React.PureComponent {
 SeaChart.propTypes = {
   clearSelectedItem: PropTypes.func.isRequired,
   clearSelectedLocation: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   disableLogic: PropTypes.bool.isRequired,
   incrementItem: PropTypes.func.isRequired,
-  decrementItem: PropTypes.func.isRequired,
   logic: PropTypes.instanceOf(LogicCalculation).isRequired,
   onlyProgressLocations: PropTypes.bool.isRequired,
   setSelectedExit: PropTypes.func.isRequired,

--- a/src/ui/sea-chart.jsx
+++ b/src/ui/sea-chart.jsx
@@ -17,6 +17,7 @@ class SeaChart extends React.PureComponent {
       clearSelectedLocation,
       disableLogic,
       incrementItem,
+      decrementItem,
       logic,
       onlyProgressLocations,
       setSelectedExit,
@@ -73,6 +74,7 @@ class SeaChart extends React.PureComponent {
         entrances={entrances}
         key={island}
         incrementItem={incrementItem}
+        decrementItem={decrementItem}
         island={island}
         numAvailable={numAvailable}
         numRemaining={numRemaining}
@@ -107,6 +109,7 @@ SeaChart.propTypes = {
   clearSelectedLocation: PropTypes.func.isRequired,
   disableLogic: PropTypes.bool.isRequired,
   incrementItem: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   logic: PropTypes.instanceOf(LogicCalculation).isRequired,
   onlyProgressLocations: PropTypes.bool.isRequired,
   setSelectedExit: PropTypes.func.isRequired,

--- a/src/ui/sector.jsx
+++ b/src/ui/sector.jsx
@@ -30,8 +30,8 @@ class Sector extends React.PureComponent {
       chartName,
       chartType,
       clearSelectedItem,
-      incrementItem,
       decrementItem,
+      incrementItem,
       setSelectedItem,
     } = this.props;
 
@@ -41,9 +41,9 @@ class Sector extends React.PureComponent {
       <div className="treasure-chart">
         <Item
           clearSelectedItem={clearSelectedItem}
+          decrementItem={decrementItem}
           images={chartImages}
           incrementItem={incrementItem}
-          decrementItem={decrementItem}
           itemCount={chartCount}
           itemName={chartName}
           setSelectedItem={setSelectedItem}
@@ -148,6 +148,7 @@ Sector.propTypes = {
   color: PropTypes.string.isRequired,
   clearSelectedItem: PropTypes.func.isRequired,
   clearSelectedLocation: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   disableLogic: PropTypes.bool.isRequired,
   entrances: PropTypes.arrayOf(
     PropTypes.shape({
@@ -157,7 +158,6 @@ Sector.propTypes = {
     }),
   ).isRequired,
   incrementItem: PropTypes.func.isRequired,
-  decrementItem: PropTypes.func.isRequired,
   island: PropTypes.string.isRequired,
   numAvailable: PropTypes.number.isRequired,
   numRemaining: PropTypes.number.isRequired,

--- a/src/ui/sector.jsx
+++ b/src/ui/sector.jsx
@@ -31,6 +31,7 @@ class Sector extends React.PureComponent {
       chartType,
       clearSelectedItem,
       incrementItem,
+      decrementItem,
       setSelectedItem,
     } = this.props;
 
@@ -42,6 +43,7 @@ class Sector extends React.PureComponent {
           clearSelectedItem={clearSelectedItem}
           images={chartImages}
           incrementItem={incrementItem}
+          decrementItem={decrementItem}
           itemCount={chartCount}
           itemName={chartName}
           setSelectedItem={setSelectedItem}
@@ -155,6 +157,7 @@ Sector.propTypes = {
     }),
   ).isRequired,
   incrementItem: PropTypes.func.isRequired,
+  decrementItem: PropTypes.func.isRequired,
   island: PropTypes.string.isRequired,
   numAvailable: PropTypes.number.isRequired,
   numRemaining: PropTypes.number.isRequired,

--- a/src/ui/tracker.jsx
+++ b/src/ui/tracker.jsx
@@ -36,6 +36,7 @@ class Tracker extends React.PureComponent {
     this.clearOpenedMenus = this.clearOpenedMenus.bind(this);
     this.clearRaceModeBannedLocations = this.clearRaceModeBannedLocations.bind(this);
     this.incrementItem = this.incrementItem.bind(this);
+    this.decrementItem = this.decrementItem.bind(this);
     this.toggleDisableLogic = this.toggleDisableLogic.bind(this);
     this.toggleEntrancesList = this.toggleEntrancesList.bind(this);
     this.toggleLocationChecked = this.toggleLocationChecked.bind(this);
@@ -107,6 +108,14 @@ class Tracker extends React.PureComponent {
     const { trackerState } = this.state;
 
     const newTrackerState = trackerState.incrementItem(itemName);
+
+    this.updateTrackerState(newTrackerState);
+  }
+
+  decrementItem(itemName) {
+    const { trackerState } = this.state;
+
+    const newTrackerState = trackerState.decrementItem(itemName);
 
     this.updateTrackerState(newTrackerState);
   }
@@ -263,6 +272,7 @@ class Tracker extends React.PureComponent {
           <div className="tracker">
             <ItemsTable
               incrementItem={this.incrementItem}
+              decrementItem={this.decrementItem}
               singleColorBackground={singleColorBackground}
               trackerState={trackerState}
             />
@@ -272,6 +282,7 @@ class Tracker extends React.PureComponent {
               disableLogic={disableLogic}
               entrancesListOpen={entrancesListOpen}
               incrementItem={this.incrementItem}
+              decrementItem={this.decrementItem}
               logic={logic}
               onlyProgressLocations={onlyProgressLocations}
               openedExit={openedExit}

--- a/src/ui/tracker.jsx
+++ b/src/ui/tracker.jsx
@@ -35,8 +35,8 @@ class Tracker extends React.PureComponent {
 
     this.clearOpenedMenus = this.clearOpenedMenus.bind(this);
     this.clearRaceModeBannedLocations = this.clearRaceModeBannedLocations.bind(this);
-    this.incrementItem = this.incrementItem.bind(this);
     this.decrementItem = this.decrementItem.bind(this);
+    this.incrementItem = this.incrementItem.bind(this);
     this.toggleDisableLogic = this.toggleDisableLogic.bind(this);
     this.toggleEntrancesList = this.toggleEntrancesList.bind(this);
     this.toggleLocationChecked = this.toggleLocationChecked.bind(this);
@@ -271,18 +271,18 @@ class Tracker extends React.PureComponent {
         <div className="tracker-container">
           <div className="tracker">
             <ItemsTable
-              incrementItem={this.incrementItem}
               decrementItem={this.decrementItem}
+              incrementItem={this.incrementItem}
               singleColorBackground={singleColorBackground}
               trackerState={trackerState}
             />
             <LocationsTable
               clearOpenedMenus={this.clearOpenedMenus}
               clearRaceModeBannedLocations={this.clearRaceModeBannedLocations}
+              decrementItem={this.decrementItem}
               disableLogic={disableLogic}
               entrancesListOpen={entrancesListOpen}
               incrementItem={this.incrementItem}
-              decrementItem={this.decrementItem}
               logic={logic}
               onlyProgressLocations={onlyProgressLocations}
               openedExit={openedExit}


### PR DESCRIPTION
## Description
This adds the ability to decrement an item count (as well as remove an item with 2 states like increment would).

Use cases that benefits would be Triforce pieces, small keys, shield, bow, sword, and wallet. Triforce pieces benefits the most as accidently clicking on it means cycling around.

This will cancel out the context menu event when clicking on items.

## Method

- Code is essentially a modification of the `incrementItem` function but reversed.
- Unit tests have also been added taking the `incrementItem` tests as reference.