### PR TITLE
Revert npm force install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install npm packages
         run: |
           set -e
-          npm install --force
+          npm install
 
       - name: Build UI
         run: |

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install npm packages
         run: |
           set -e
-          npm install --force
+          npm install
 
       - name: Build UI
         run: |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Building and running the tracker locally requires you to [install Node 18](https
 
 After installing Node and cloning the repository, install the required dependencies:
 ```bash
-npm install --force
+npm install
 ```
 You can then build and serve the tracker application:
 ```bash


### PR DESCRIPTION
The previous issue with `react-loader-spinner` was fixed in https://github.com/mhnpd/react-loader-spinner/pull/129.