### PR TITLE
Right clicking a sector clears all locations

### DIFF
--- a/src/ui/extra-location.jsx
+++ b/src/ui/extra-location.jsx
@@ -9,6 +9,7 @@ import Settings from '../services/settings';
 import Spheres from '../services/spheres';
 import TrackerState from '../services/tracker-state';
 
+import ContextMenuWrapper from './context-menu-wrapper';
 import Images from './images';
 import Item from './item';
 import KeyDownWrapper from './key-down-wrapper';
@@ -378,6 +379,7 @@ class ExtraLocation extends React.PureComponent {
 
   render() {
     const {
+      clearAllLocations,
       clearSelectedLocation,
       isDungeon,
       locationName,
@@ -392,11 +394,18 @@ class ExtraLocation extends React.PureComponent {
 
     const setSelectedLocationFunc = () => setSelectedLocation({ locationName });
 
+    const clearAllLocationsFunc = (event) => {
+      event.preventDefault();
+
+      clearAllLocations(locationName);
+    };
+
     return (
       <div
         className="extra-location"
         onBlur={clearSelectedLocation}
         onClick={updateOpenedLocationFunc}
+        onContextMenu={ContextMenuWrapper.onRightClick(clearAllLocationsFunc)}
         onFocus={setSelectedLocationFunc}
         onKeyDown={KeyDownWrapper.onSpaceKey(updateOpenedLocationFunc)}
         onMouseOver={setSelectedLocationFunc}
@@ -414,6 +423,7 @@ class ExtraLocation extends React.PureComponent {
 }
 
 ExtraLocation.propTypes = {
+  clearAllLocations: PropTypes.func.isRequired,
   clearSelectedItem: PropTypes.func.isRequired,
   clearSelectedLocation: PropTypes.func.isRequired,
   decrementItem: PropTypes.func.isRequired,

--- a/src/ui/extra-locations-table.jsx
+++ b/src/ui/extra-locations-table.jsx
@@ -19,6 +19,7 @@ class ExtraLocationsTable extends React.PureComponent {
 
   extraLocation(locationName) {
     const {
+      clearAllLocations,
       clearSelectedItem,
       clearSelectedLocation,
       decrementItem,
@@ -45,6 +46,7 @@ class ExtraLocationsTable extends React.PureComponent {
 
     return (
       <ExtraLocation
+        clearAllLocations={clearAllLocations}
         clearSelectedItem={clearSelectedItem}
         clearSelectedLocation={clearSelectedLocation}
         decrementItem={decrementItem}
@@ -101,6 +103,7 @@ ExtraLocationsTable.defaultProps = {
 
 ExtraLocationsTable.propTypes = {
   backgroundColor: PropTypes.string,
+  clearAllLocations: PropTypes.func.isRequired,
   clearSelectedItem: PropTypes.func.isRequired,
   clearSelectedLocation: PropTypes.func.isRequired,
   decrementItem: PropTypes.func.isRequired,

--- a/src/ui/locations-table.jsx
+++ b/src/ui/locations-table.jsx
@@ -224,6 +224,7 @@ class LocationsTable extends React.PureComponent {
   render() {
     const {
       backgroundColor,
+      clearAllLocations,
       decrementItem,
       disableLogic,
       incrementItem,
@@ -245,6 +246,7 @@ class LocationsTable extends React.PureComponent {
         {this.chartContainer()}
         <ExtraLocationsTable
           backgroundColor={backgroundColor}
+          clearAllLocations={clearAllLocations}
           clearSelectedItem={this.clearSelectedItem}
           clearSelectedLocation={this.clearSelectedLocation}
           decrementItem={decrementItem}

--- a/src/ui/locations-table.jsx
+++ b/src/ui/locations-table.jsx
@@ -173,6 +173,7 @@ class LocationsTable extends React.PureComponent {
     } else {
       chartElement = (
         <SeaChart
+          clearAllLocations={clearAllLocations}
           clearSelectedChartForIsland={this.clearSelectedChartForIsland}
           clearSelectedItem={this.clearSelectedItem}
           clearSelectedLocation={this.clearSelectedLocation}

--- a/src/ui/sea-chart.jsx
+++ b/src/ui/sea-chart.jsx
@@ -13,6 +13,7 @@ import Sector from './sector';
 class SeaChart extends React.PureComponent {
   sector(island) {
     const {
+      clearAllLocations,
       clearSelectedChartForIsland,
       clearSelectedItem,
       clearSelectedLocation,
@@ -42,6 +43,7 @@ class SeaChart extends React.PureComponent {
 
     return (
       <Sector
+        clearAllLocations={clearAllLocations}
         clearSelectedChartForIsland={clearSelectedChartForIsland}
         clearSelectedItem={clearSelectedItem}
         clearSelectedLocation={clearSelectedLocation}
@@ -90,6 +92,7 @@ class SeaChart extends React.PureComponent {
 }
 
 SeaChart.propTypes = {
+  clearAllLocations: PropTypes.func.isRequired,
   clearSelectedChartForIsland: PropTypes.func.isRequired,
   clearSelectedItem: PropTypes.func.isRequired,
   clearSelectedLocation: PropTypes.func.isRequired,

--- a/src/ui/sector.jsx
+++ b/src/ui/sector.jsx
@@ -9,6 +9,7 @@ import Settings from '../services/settings';
 import Spheres from '../services/spheres';
 import TrackerState from '../services/tracker-state';
 
+import ContextMenuWrapper from './context-menu-wrapper';
 import Images from './images';
 import Item from './item';
 import KeyDownWrapper from './key-down-wrapper';
@@ -279,6 +280,7 @@ class Sector extends React.PureComponent {
 
   render() {
     const {
+      clearAllLocations,
       clearSelectedLocation,
       island,
       setSelectedLocation,
@@ -296,11 +298,18 @@ class Sector extends React.PureComponent {
 
     const setSelectedLocationFunc = () => setSelectedLocation({ locationName: island });
 
+    const clearAllLocationsFunc = (event) => {
+      event.preventDefault();
+
+      clearAllLocations(island);
+    };
+
     return (
       <div
         className="sea-sector"
         onBlur={clearSelectedLocation}
         onClick={updateOpenedLocationFunc}
+        onContextMenu={ContextMenuWrapper.onRightClick(clearAllLocationsFunc)}
         onFocus={setSelectedLocationFunc}
         onKeyDown={KeyDownWrapper.onSpaceKey(updateOpenedLocationFunc)}
         onMouseOver={setSelectedLocationFunc}
@@ -317,6 +326,7 @@ class Sector extends React.PureComponent {
 }
 
 Sector.propTypes = {
+  clearAllLocations: PropTypes.func.isRequired,
   clearSelectedChartForIsland: PropTypes.func.isRequired,
   clearSelectedItem: PropTypes.func.isRequired,
   clearSelectedLocation: PropTypes.func.isRequired,


### PR DESCRIPTION
A right click on a sector on the sea chart now has the same effect as opening the sector and clicking "Check All", to allow for easier marking of barren hints and full clears of islands.