### PR TITLE
Fix S8 permalink

### DIFF
--- a/src/services/logic-loader.js
+++ b/src/services/logic-loader.js
@@ -27,7 +27,7 @@ class LogicLoader {
   }
 
   static #logicFileUrl(fileName) {
-    return `https://raw.githubusercontent.com/LagoLunatic/wwrando/${Settings.getVersion()}/logic/${fileName}`;
+    return `https://raw.githubusercontent.com/tanjo3/wwrando/${Settings.getVersion()}/logic/${fileName}`;
   }
 }
 

--- a/src/services/permalink.js
+++ b/src/services/permalink.js
@@ -29,7 +29,7 @@ class Permalink {
     [this.OPTIONS.SWORD_MODE]: SWORD_MODE_OPTIONS,
   };
 
-  static DEFAULT_PERMALINK = 'eJwLtlAIyS8tykvMTc0rUSgzjDdJMTc3szRlcGS4+7mIo8GYQcDBkQEIGoCon1EAxJRgsnOuN/gov+F/tgkDGNzxaOBweXJa3cZWnkHA4x8TUI0DgwiDK2OFBhcAM80Y0g==';
+  static DEFAULT_PERMALINK = 'eJwLtlAIyS8tykvMTc0rUSgzYnBkuPu5iKPBmEHAwZEBCBqAqJ9RAMSUYLJzrjf4KL/hf7YJAxjc8WjgcHlyWt3GVp5BwOMfE1CNA4MIgytjhQYXAGZ7Fso=';
 
   static getVersion(binaryString) {
     const clonedString = binaryString.clone();

--- a/src/services/settings.js
+++ b/src/services/settings.js
@@ -144,10 +144,13 @@ class Settings {
   };
 
   static #parseVersion(version) {
-    const commitHashMatch = version.match(/([a-f\d]){7,}/);
-    const versionMatch = version.match(/^[0-9.]+$/);
+    const s8VersionMatch = version.match(/(v\d+)/);
+    if (_.first(s8VersionMatch)) {
+      return `s8-${_.first(s8VersionMatch)}`;
+    }
 
-    return _.first(commitHashMatch) || _.first(versionMatch) || 'master';
+    const commitHashMatch = version.match(/([a-f\d]){7,}/);
+    return _.first(commitHashMatch) || 'master';
   }
 }
 


### PR DESCRIPTION
This PR changes the default S8 permalink to use v2. Also, changes the version parsing to use S8 versioning style, as I was not fully aware about how commits work.