### PR TITLE
Fix overworld rupees not being properly excluded

### DIFF
--- a/src/services/logic-helper.js
+++ b/src/services/logic-helper.js
@@ -370,7 +370,7 @@ class LogicHelper {
       Locations.KEYS.TYPES,
     );
 
-    if (!locationTypes) {
+    if (_.isNil(locationTypes)) {
       // the Defeat Ganondorf location does not have any types
       return true;
     }


### PR DESCRIPTION
The "Rupee" tag gets stripped from location types, so overworld rupees end up having no types. This causes `isProgressLocation` to exit early due to the check for the "Defeat Ganondorf" location. That location has `undefined` type (there is no type entry in its location data), whereas rupeesanity locations just have an empty type. So, to fix, we change the check for the "Defeat Ganondorf" to use `isNil` instead. This is also why dungeon and secret caves rupees worked: their types were non-empty after the "Rupee" tag was removed.

Report: https://discord.com/channels/453718509600374794/1493320873451716760