### PR TITLE
This PR refactors the Settings window by introducing tab-based navigation and adding support for repositioning the window.

### DIFF
--- a/src/ui/settings-window.jsx
+++ b/src/ui/settings-window.jsx
@@ -14,6 +14,140 @@ class SettingsWindow extends React.PureComponent {
 
   static #DEFAULT_SPHERE_TRACKING_BACKGROUND = '#dcdcdc';
 
+  constructor(props) {
+    super(props);
+
+    this.settingsWindowRef = React.createRef();
+
+    this.state = {
+      activeTab: 'general',
+      dragging: false,
+      dragOffset: null,
+      dragPosition: props.settingsWindowPosition,
+    };
+
+    this.handleMouseDown = this.handleMouseDown.bind(this);
+    this.handleMouseMove = this.handleMouseMove.bind(this);
+    this.handleMouseUp = this.handleMouseUp.bind(this);
+    this.keepInBounds = this.keepInBounds.bind(this);
+  }
+
+  handleMouseDown(event) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const {
+      dragPosition,
+    } = this.state;
+
+    this.setState({
+      dragging: true,
+      dragOffset: {
+        x: event.clientX - dragPosition.x,
+        y: event.clientY - dragPosition.y,
+      },
+    });
+  }
+
+  handleMouseMove(event) {
+    const {
+      dragging,
+      dragOffset,
+    } = this.state;
+
+    if (!dragging || !dragOffset) {
+      return;
+    }
+
+    const windowElement = this.settingsWindowRef.current;
+
+    if (!windowElement) {
+      return;
+    }
+
+    const width = windowElement.offsetWidth;
+    const height = windowElement.offsetHeight;
+
+    const maxX = Math.max(window.innerWidth - width, 0);
+    const maxY = Math.max(window.innerHeight - height, 0);
+
+    this.setState({
+      dragPosition: {
+        x: Math.min(Math.max(event.clientX - dragOffset.x, 0), maxX),
+        y: Math.min(Math.max(event.clientY - dragOffset.y, 0), maxY),
+      },
+    });
+  }
+
+  handleMouseUp() {
+    const {
+      dragging,
+      dragPosition,
+    } = this.state;
+
+    if (!dragging) {
+      return;
+    }
+
+    this.props.updateSettingsWindowPosition(dragPosition);
+
+    this.setState({
+      dragging: false,
+      dragOffset: null,
+    });
+  }
+
+  componentDidMount() {
+    document.addEventListener('mousemove', this.handleMouseMove);
+    document.addEventListener('mouseup', this.handleMouseUp);
+    window.addEventListener('resize', this.keepInBounds);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousemove', this.handleMouseMove);
+    document.removeEventListener('mouseup', this.handleMouseUp);
+    window.removeEventListener('resize', this.keepInBounds);
+  }
+
+  keepInBounds() {
+    const element = this.settingsWindowRef.current;
+
+    if (!element) {
+      return;
+    }
+
+    const { dragPosition } = this.state;
+
+    const maxX = Math.max(
+      window.innerWidth - element.offsetWidth,
+      0,
+    );
+
+    const maxY = Math.max(
+      window.innerHeight - element.offsetHeight,
+      0,
+    );
+
+    const newPosition = {
+      x: Math.min(Math.max(dragPosition.x, 0), maxX),
+      y: Math.min(Math.max(dragPosition.y, 0), maxY),
+    };
+
+    if (
+      newPosition.x !== dragPosition.x ||
+      newPosition.y !== dragPosition.y
+    ) {
+      this.setState({
+        dragPosition: newPosition,
+      });
+
+      this.props.updateSettingsWindowPosition(newPosition);
+    }
+  }
+
   colorPickerRow(label, pickedColor, key, defaultValue) {
     const isColorSet = !_.isNil(pickedColor);
     const labelText = `Override ${label} Background Color`;
@@ -60,7 +194,12 @@ class SettingsWindow extends React.PureComponent {
     );
   }
 
-  checkboxRow(labelText, pickedValue, key, getCheckedValue = (value) => value) {
+  checkboxRow(
+    labelText,
+    pickedValue,
+    key,
+    getCheckedValue = (value) => value,
+  ) {
     const checkboxId = `${key}-checkbox`;
 
     const toggleFunc = () => {
@@ -88,7 +227,22 @@ class SettingsWindow extends React.PureComponent {
     );
   }
 
+  settingsTab(label, tab) {
+    return (
+      <button
+        onClick={() => this.setState({ activeTab: tab })}
+        type="button"
+      >
+        {label}
+      </button>
+    );
+  }
+
   render() {
+    const {
+      activeTab,
+      dragPosition,
+    } = this.state;
     const {
       clearAllIncludesMail,
       disableLogic,
@@ -96,24 +250,37 @@ class SettingsWindow extends React.PureComponent {
       itemsTableBackground,
       rightClickToClearAll,
       showBeedleLocations,
-      showSalvageCorpLocations,
       showCyclosLocations,
       showGhostShipLocations,
+      showSalvageCorpLocations,
       sphereTrackingBackground,
       statisticsBackground,
       toggleSettingsWindow,
-      trackNonProgressCharts,
       trackNonProgressBlueChuJelly,
+      trackNonProgressCharts,
       trackSpheres,
     } = this.props;
 
     return (
-      <div className="settings-window">
-        <div className="settings-window-top-row">
-          <div className="settings-window-title">Settings</div>
+      <div
+        ref={this.settingsWindowRef}
+        className="settings-window"
+        style={{
+          left: `${dragPosition.x}px`,
+          top: `${dragPosition.y}px`,
+        }}
+      >
+        <div
+          className="settings-window-top-row"
+          onMouseDown={this.handleMouseDown}
+        >
+          <div className="settings-window-title">
+            Settings
+          </div>
           <div
             className="close-button"
             onClick={toggleSettingsWindow}
+            onMouseDown={(event) => event.stopPropagation()}
             onKeyDown={KeyDownWrapper.onSpaceKey(toggleSettingsWindow)}
             role="button"
             tabIndex="0"
@@ -121,80 +288,101 @@ class SettingsWindow extends React.PureComponent {
             X Close
           </div>
         </div>
-        {this.colorPickerRow(
-          'Locations',
-          extraLocationsBackground,
-          'extraLocationsBackground',
-          SettingsWindow.#DEFAULT_EXTRA_LOCATIONS_BACKGROUND,
+
+        <div className="settings-tabs">
+          {this.settingsTab('General', 'general')}
+          {this.settingsTab('Display', 'display')}
+          {this.settingsTab('Colors', 'colors')}
+        </div>
+
+        {activeTab === 'general' && (
+          <>
+            {this.checkboxRow(
+              'Track Spheres',
+              trackSpheres,
+              'trackSpheres',
+            )}
+            {this.checkboxRow(
+              'Track Non-Progress Charts',
+              trackNonProgressCharts,
+              'trackNonProgressCharts',
+            )}
+            {this.checkboxRow(
+              'Track Non-Progress Blue Chu Jelly',
+              trackNonProgressBlueChuJelly,
+              'trackNonProgressBlueChuJelly',
+            )}
+            {this.checkboxRow(
+              'Right Click to Clear All',
+              rightClickToClearAll,
+              'rightClickToClearAll',
+            )}
+            {this.checkboxRow(
+              'Clear All Includes Dungeon Mail',
+              clearAllIncludesMail,
+              'clearAllIncludesMail',
+            )}
+          </>
         )}
-        {this.colorPickerRow(
-          'Items',
-          itemsTableBackground,
-          'itemsTableBackground',
-          SettingsWindow.#DEFAULT_ITEMS_TABLE_BACKGROUND,
+        {activeTab === 'display' && (
+          <>
+            {this.checkboxRow(
+              'Show Location Logic',
+              disableLogic,
+              'disableLogic',
+              (value) => !value,
+            )}
+            {this.checkboxRow(
+              'Show 20 Rupee Beedle Locations',
+              showBeedleLocations,
+              'showBeedleLocations',
+            )}
+            {this.checkboxRow(
+              'Show Salvage Corp Locations',
+              showSalvageCorpLocations,
+              'showSalvageCorpLocations',
+            )}
+            {this.checkboxRow(
+              'Show Cyclos Locations',
+              showCyclosLocations,
+              'showCyclosLocations',
+            )}
+            {this.checkboxRow(
+              'Show Ghost Ship Locations',
+              showGhostShipLocations,
+              'showGhostShipLocations',
+            )}
+          </>
         )}
-        {this.colorPickerRow(
-          'Statistics',
-          statisticsBackground,
-          'statisticsBackground',
-          SettingsWindow.#DEFAULT_STATISTICS_BACKGROUND,
-        )}
-        {this.colorPickerRow(
-          'Sphere Tracking',
-          sphereTrackingBackground,
-          'sphereTrackingBackground',
-          SettingsWindow.#DEFAULT_SPHERE_TRACKING_BACKGROUND,
-        )}
-        {this.checkboxRow(
-          'Show Location Logic',
-          disableLogic,
-          'disableLogic',
-          (value) => !value,
-        )}
-        {this.checkboxRow(
-          'Track Spheres',
-          trackSpheres,
-          'trackSpheres',
-        )}
-        {this.checkboxRow(
-          'Track Non-Progress Charts',
-          trackNonProgressCharts,
-          'trackNonProgressCharts',
-        )}
-        {this.checkboxRow(
-          'Track Non-Progress Blue Chu Jelly',
-          trackNonProgressBlueChuJelly,
-          'trackNonProgressBlueChuJelly',
-        )}
-        {this.checkboxRow(
-          'Show 20 Rupee Beedle Locations',
-          showBeedleLocations,
-          'showBeedleLocations',
-        )}
-        {this.checkboxRow(
-          'Show Salvage Corp Locations',
-          showSalvageCorpLocations,
-          'showSalvageCorpLocations',
-        )}
-        {this.checkboxRow(
-          'Show Cyclos Locations',
-          showCyclosLocations,
-          'showCyclosLocations',
-        )}
-        {this.checkboxRow(
-          'Show Ghost Ship Locations',
-          showGhostShipLocations,
-          'showGhostShipLocations',
-        )}
-        {this.checkboxRow(
-          'Right Click to Clear All',
-          rightClickToClearAll,
-          'rightClickToClearAll',
-        )}
-        {this.checkboxRow(
-          'Clear All Includes Dungeon Mail',
-          clearAllIncludesMail,
-          'clearAllIncludesMail',
+
+        {activeTab === 'colors' && (
+          <>
+            {this.colorPickerRow(
+              'Locations',
+              extraLocationsBackground,
+              'extraLocationsBackground',
+              SettingsWindow.#DEFAULT_EXTRA_LOCATIONS_BACKGROUND,
+            )}
+            {this.colorPickerRow(
+              'Items',
+              itemsTableBackground,
+              'itemsTableBackground',
+              SettingsWindow.#DEFAULT_ITEMS_TABLE_BACKGROUND,
+            )}
+            {this.colorPickerRow(
+              'Statistics',
+              statisticsBackground,
+              'statisticsBackground',
+              SettingsWindow.#DEFAULT_STATISTICS_BACKGROUND,
+            )}
+
+            {this.colorPickerRow(
+              'Sphere Tracking',
+              sphereTrackingBackground,
+              'sphereTrackingBackground',
+              SettingsWindow.#DEFAULT_SPHERE_TRACKING_BACKGROUND,
+            )}
+          </>
         )}
       </div>
     );
@@ -206,6 +394,10 @@ SettingsWindow.defaultProps = {
   itemsTableBackground: null,
   sphereTrackingBackground: null,
   statisticsBackground: null,
+  settingsWindowPosition: {
+    x: 20,
+    y: 300,
+  },
 };
 
 SettingsWindow.propTypes = {
@@ -214,17 +406,22 @@ SettingsWindow.propTypes = {
   extraLocationsBackground: PropTypes.string,
   itemsTableBackground: PropTypes.string,
   rightClickToClearAll: PropTypes.bool.isRequired,
+  settingsWindowPosition: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+  }).isRequired,
   showBeedleLocations: PropTypes.bool.isRequired,
-  showSalvageCorpLocations: PropTypes.bool.isRequired,
   showCyclosLocations: PropTypes.bool.isRequired,
   showGhostShipLocations: PropTypes.bool.isRequired,
+  showSalvageCorpLocations: PropTypes.bool.isRequired,
   sphereTrackingBackground: PropTypes.string,
   statisticsBackground: PropTypes.string,
-  trackNonProgressCharts: PropTypes.bool.isRequired,
   trackNonProgressBlueChuJelly: PropTypes.bool.isRequired,
-  toggleSettingsWindow: PropTypes.func.isRequired,
+  trackNonProgressCharts: PropTypes.bool.isRequired,
   trackSpheres: PropTypes.bool.isRequired,
+  toggleSettingsWindow: PropTypes.func.isRequired,
   updatePreferences: PropTypes.func.isRequired,
+  updateSettingsWindowPosition: PropTypes.func.isRequired,
 };
 
 export default SettingsWindow;

--- a/src/ui/settings-window.jsx
+++ b/src/ui/settings-window.jsx
@@ -32,6 +32,18 @@ class SettingsWindow extends React.PureComponent {
     this.keepInBounds = this.keepInBounds.bind(this);
   }
 
+  componentDidMount() {
+    document.addEventListener('mousemove', this.handleMouseMove);
+    document.addEventListener('mouseup', this.handleMouseUp);
+    window.addEventListener('resize', this.keepInBounds);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousemove', this.handleMouseMove);
+    document.removeEventListener('mouseup', this.handleMouseUp);
+    window.removeEventListener('resize', this.keepInBounds);
+  }
+
   handleMouseDown(event) {
     if (event.button !== 0) {
       return;
@@ -92,7 +104,11 @@ class SettingsWindow extends React.PureComponent {
       return;
     }
 
-    this.props.updateSettingsWindowPosition(dragPosition);
+    const {
+      updateSettingsWindowPosition,
+    } = this.props;
+
+    updateSettingsWindowPosition(dragPosition);
 
     this.setState({
       dragging: false,
@@ -100,16 +116,15 @@ class SettingsWindow extends React.PureComponent {
     });
   }
 
-  componentDidMount() {
-    document.addEventListener('mousemove', this.handleMouseMove);
-    document.addEventListener('mouseup', this.handleMouseUp);
-    window.addEventListener('resize', this.keepInBounds);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('mousemove', this.handleMouseMove);
-    document.removeEventListener('mouseup', this.handleMouseUp);
-    window.removeEventListener('resize', this.keepInBounds);
+  settingsTab(label, tab) {
+    return (
+      <button
+        onClick={() => this.setState({ activeTab: tab })}
+        type="button"
+      >
+        {label}
+      </button>
+    );
   }
 
   keepInBounds() {
@@ -137,14 +152,18 @@ class SettingsWindow extends React.PureComponent {
     };
 
     if (
-      newPosition.x !== dragPosition.x ||
-      newPosition.y !== dragPosition.y
+      newPosition.x !== dragPosition.x
+      || newPosition.y !== dragPosition.y
     ) {
       this.setState({
         dragPosition: newPosition,
       });
 
-      this.props.updateSettingsWindowPosition(newPosition);
+      const {
+        updateSettingsWindowPosition,
+      } = this.props;
+
+      updateSettingsWindowPosition(newPosition);
     }
   }
 
@@ -227,17 +246,6 @@ class SettingsWindow extends React.PureComponent {
     );
   }
 
-  settingsTab(label, tab) {
-    return (
-      <button
-        onClick={() => this.setState({ activeTab: tab })}
-        type="button"
-      >
-        {label}
-      </button>
-    );
-  }
-
   render() {
     const {
       activeTab,
@@ -273,6 +281,9 @@ class SettingsWindow extends React.PureComponent {
         <div
           className="settings-window-top-row"
           onMouseDown={this.handleMouseDown}
+          onKeyDown={() => {}}
+          role="button"
+          tabIndex={0}
         >
           <div className="settings-window-title">
             Settings
@@ -394,10 +405,10 @@ SettingsWindow.defaultProps = {
   itemsTableBackground: null,
   sphereTrackingBackground: null,
   statisticsBackground: null,
-  settingsWindowPosition: {
-    x: 20,
-    y: 300,
-  },
+  settingsWindowPosition: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+  }),
 };
 
 SettingsWindow.propTypes = {
@@ -409,7 +420,7 @@ SettingsWindow.propTypes = {
   settingsWindowPosition: PropTypes.shape({
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
-  }).isRequired,
+  }),
   showBeedleLocations: PropTypes.bool.isRequired,
   showCyclosLocations: PropTypes.bool.isRequired,
   showGhostShipLocations: PropTypes.bool.isRequired,

--- a/src/ui/tracker.jsx
+++ b/src/ui/tracker.jsx
@@ -42,6 +42,10 @@ class Tracker extends React.PureComponent {
       openedLocation: null,
       openedLocationIsDungeon: null,
       rightClickToClearAll: true,
+      settingsWindowPosition: {
+        x: 20,
+        y: 300,
+      },
       showBeedleLocations: false,
       showSalvageCorpLocations: false,
       showCyclosLocations: false,
@@ -74,6 +78,7 @@ class Tracker extends React.PureComponent {
     this.updateOpenedExit = this.updateOpenedExit.bind(this);
     this.updateOpenedLocation = this.updateOpenedLocation.bind(this);
     this.updatePreferences = this.updatePreferences.bind(this);
+    this.updateSettingsWindowPosition = this.updateSettingsWindowPosition.bind(this);
   }
 
   async initialize() {
@@ -403,6 +408,12 @@ class Tracker extends React.PureComponent {
     this.setState({ lastLocation: null });
   }
 
+  updateSettingsWindowPosition(position) {
+    this.updatePreferences({
+      settingsWindowPosition: position,
+    });
+  }
+
   updatePreferences(preferenceChanges) {
     const {
       clearAllIncludesMail,
@@ -410,6 +421,7 @@ class Tracker extends React.PureComponent {
       onlyProgressLocations,
       colors,
       rightClickToClearAll,
+      settingsWindowPosition,
       showBeedleLocations,
       showSalvageCorpLocations,
       showCyclosLocations,
@@ -426,6 +438,7 @@ class Tracker extends React.PureComponent {
       disableLogic,
       onlyProgressLocations,
       rightClickToClearAll,
+      settingsWindowPosition,
       showBeedleLocations,
       showSalvageCorpLocations,
       showCyclosLocations,
@@ -460,6 +473,7 @@ class Tracker extends React.PureComponent {
       rightClickToClearAll,
       saveData,
       settingsWindowOpen,
+      settingsWindowPosition,
       spheres,
       showBeedleLocations,
       showSalvageCorpLocations,
@@ -560,6 +574,7 @@ class Tracker extends React.PureComponent {
               extraLocationsBackground={extraLocationsBackground}
               itemsTableBackground={itemsTableBackground}
               rightClickToClearAll={rightClickToClearAll}
+              settingsWindowPosition={settingsWindowPosition}
               showBeedleLocations={showBeedleLocations}
               showSalvageCorpLocations={showSalvageCorpLocations}
               showCyclosLocations={showCyclosLocations}
@@ -571,6 +586,7 @@ class Tracker extends React.PureComponent {
               trackNonProgressBlueChuJelly={trackNonProgressBlueChuJelly}
               trackSpheres={trackSpheres}
               updatePreferences={this.updatePreferences}
+              updateSettingsWindowPosition={this.updateSettingsWindowPosition}
             />
           )}
           <Buttons


### PR DESCRIPTION
## Changes

* Split the Settings window into three dedicated tabs:

  * **General** — general application settings
  * **Display** — display-related options
  * **Colors** — color customization settings
* Added support for dragging the Settings window to reposition it.
* Added support for retaining the Settings window position and restoring it when reopened.

